### PR TITLE
Multiple configurable pool limit tiers

### DIFF
--- a/src/zkbob/utils/ZkBobAccounting.sol
+++ b/src/zkbob/utils/ZkBobAccounting.sol
@@ -48,7 +48,7 @@ contract ZkBobAccounting {
         uint32 dailyWithdrawal;
     }
 
-    struct Slot2 {
+    struct PoolLimits {
         // max cap on the entire pool tvl (granularity of 1e9)
         // max possible cap - type(uint56).max * 1e9 zkBOB units ~= 7.2e16 BOB
         uint56 tvlCap;
@@ -72,9 +72,10 @@ contract ZkBobAccounting {
         uint88 cumTvl; // cumulative sum of tvl over txCount interactions (granularity of 1e9)
     }
 
-    struct UserDailyStats {
+    struct UserStats {
         uint16 day; // last update day number
         uint72 dailyDeposit; // sum of user deposits during given day
+        uint8 tier; // user limits tier, 0 being the default tier
     }
 
     struct Limits {
@@ -87,13 +88,16 @@ contract ZkBobAccounting {
         uint256 dailyUserDepositCap;
         uint256 dailyUserDepositCapUsage;
         uint256 depositCap;
+        uint8 tier;
     }
 
     Slot0 private slot0;
     Slot1 private slot1;
-    Slot2 private slot2;
+    mapping(uint256 => PoolLimits) private poolLimits; // pool limits per tier
     mapping(uint256 => Snapshot) private snapshots; // single linked list of hourly snapshots
-    mapping(address => UserDailyStats) private userStats;
+    mapping(address => UserStats) private userStats;
+
+    event UpdateTier(address user, uint8 tier);
 
     /**
      * @dev Returns currently configured limits and remaining quotas for the given user as of the current block.
@@ -103,20 +107,21 @@ contract ZkBobAccounting {
     function getLimitsFor(address _user) external view returns (Limits memory) {
         Slot0 memory s0 = slot0;
         Slot1 memory s1 = slot1;
-        Slot2 memory s2 = slot2;
+        UserStats memory us = userStats[_user];
+        PoolLimits memory pl = poolLimits[uint256(us.tier)];
         uint24 curSlot = uint24(block.timestamp / SLOT_DURATION);
         uint24 today = curSlot / uint24(DAY_SLOTS);
-        UserDailyStats memory us = userStats[_user];
         return Limits({
-            tvlCap: s2.tvlCap * PRECISION,
+            tvlCap: pl.tvlCap * PRECISION,
             tvl: s1.tvl,
-            dailyDepositCap: s2.dailyDepositCap * PRECISION,
+            dailyDepositCap: pl.dailyDepositCap * PRECISION,
             dailyDepositCapUsage: (s0.headSlot / DAY_SLOTS == today) ? s1.dailyDeposit * PRECISION : 0,
-            dailyWithdrawalCap: s2.dailyWithdrawalCap * PRECISION,
+            dailyWithdrawalCap: pl.dailyWithdrawalCap * PRECISION,
             dailyWithdrawalCapUsage: (s0.headSlot / DAY_SLOTS == today) ? s1.dailyWithdrawal * PRECISION : 0,
-            dailyUserDepositCap: s2.dailyUserDepositCap * PRECISION,
+            dailyUserDepositCap: pl.dailyUserDepositCap * PRECISION,
             dailyUserDepositCapUsage: (us.day == today) ? us.dailyDeposit : 0,
-            depositCap: s2.depositCap * PRECISION
+            depositCap: pl.depositCap * PRECISION,
+            tier: us.tier
         });
     }
 
@@ -171,7 +176,9 @@ contract ZkBobAccounting {
             return;
         }
 
-        Slot2 memory s2 = slot2;
+        UserStats memory us = userStats[_user];
+        PoolLimits memory pl = poolLimits[us.tier];
+
         uint16 curDay = uint16(block.timestamp / SLOT_DURATION / DAY_SLOTS);
 
         if (_txAmount > 0) {
@@ -179,17 +186,16 @@ contract ZkBobAccounting {
             s1.tvl += uint72(depositAmount);
 
             // check all sorts of limits when processing a deposit
-            require(depositAmount <= uint256(s2.depositCap) * PRECISION, "ZkBobAccounting: single deposit cap exceeded");
-            require(uint256(s1.tvl) <= uint256(s2.tvlCap) * PRECISION, "ZkBobAccounting: tvl cap exceeded");
+            require(depositAmount <= uint256(pl.depositCap) * PRECISION, "ZkBobAccounting: single deposit cap exceeded");
+            require(uint256(s1.tvl) <= uint256(pl.tvlCap) * PRECISION, "ZkBobAccounting: tvl cap exceeded");
 
-            UserDailyStats memory us = userStats[_user];
             if (curDay > us.day) {
                 // user snapshot is outdated, day number and daily sum could be reset
-                userStats[_user] = UserDailyStats(curDay, uint72(depositAmount));
+                userStats[_user] = UserStats(curDay, uint72(depositAmount), us.tier);
             } else {
                 us.dailyDeposit += uint72(depositAmount);
                 require(
-                    uint256(us.dailyDeposit) <= uint256(s2.dailyUserDepositCap) * PRECISION,
+                    uint256(us.dailyDeposit) <= uint256(pl.dailyUserDepositCap) * PRECISION,
                     "ZkBobAccounting: daily user deposit cap exceeded"
                 );
                 userStats[_user] = us;
@@ -200,7 +206,7 @@ contract ZkBobAccounting {
                 s1.dailyDeposit = uint32(depositAmount / PRECISION);
             } else {
                 s1.dailyDeposit += uint32(depositAmount / PRECISION);
-                require(s1.dailyDeposit <= s2.dailyDepositCap, "ZkBobAccounting: daily deposit cap exceeded");
+                require(s1.dailyDeposit <= pl.dailyDepositCap, "ZkBobAccounting: daily deposit cap exceeded");
             }
         } else {
             uint256 withdrawAmount = uint256(-_txAmount);
@@ -211,7 +217,7 @@ contract ZkBobAccounting {
                 s1.dailyWithdrawal = uint32(withdrawAmount / PRECISION);
             } else {
                 s1.dailyWithdrawal += uint32(withdrawAmount / PRECISION);
-                require(s1.dailyWithdrawal <= s2.dailyWithdrawalCap, "ZkBobAccounting: daily withdrawal cap exceeded");
+                require(s1.dailyWithdrawal <= pl.dailyWithdrawalCap, "ZkBobAccounting: daily withdrawal cap exceeded");
             }
         }
 
@@ -219,6 +225,7 @@ contract ZkBobAccounting {
     }
 
     function _setLimits(
+        uint8 _tier,
         uint256 _tvlCap,
         uint256 _dailyDepositCap,
         uint256 _dailyWithdrawalCap,
@@ -227,20 +234,28 @@ contract ZkBobAccounting {
     )
         internal
     {
-        Slot1 memory s1 = slot1;
-        Slot2 memory s2 = slot2;
+        require(_tier < 255, "ZkBobAccounting: invalid limit tier");
         require(_depositCap > 0, "ZkBobAccounting: zero deposit cap");
         require(_dailyUserDepositCap >= _depositCap, "ZkBobAccounting: daily user deposit cap too low");
         require(_dailyDepositCap >= _dailyUserDepositCap, "ZkBobAccounting: daily deposit cap too low");
         require(_tvlCap >= _dailyDepositCap, "ZkBobAccounting: tvl cap too low");
-        require(_tvlCap >= s1.tvl, "ZkBobAccounting: tvl cap lower than current tvl");
         require(_dailyWithdrawalCap > 0, "ZkBobAccounting: zero daily withdrawal cap");
-        s2.tvlCap = uint56(_tvlCap / PRECISION);
-        s2.dailyDepositCap = uint32(_dailyDepositCap / PRECISION);
-        s2.dailyWithdrawalCap = uint32(_dailyWithdrawalCap / PRECISION);
-        s2.dailyUserDepositCap = uint32(_dailyUserDepositCap / PRECISION);
-        s2.depositCap = uint32(_depositCap / PRECISION);
-        slot2 = s2;
+        poolLimits[_tier] = PoolLimits({
+            tvlCap: uint56(_tvlCap / PRECISION),
+            dailyDepositCap: uint32(_dailyDepositCap / PRECISION),
+            dailyWithdrawalCap: uint32(_dailyWithdrawalCap / PRECISION),
+            dailyUserDepositCap: uint32(_dailyUserDepositCap / PRECISION),
+            depositCap: uint32(_depositCap / PRECISION)
+        });
+    }
+
+    function _setUsersTier(uint8 _tier, address[] memory _users) internal {
+        require(_tier == 255 || poolLimits[uint256(_tier)].tvlCap > 0, "ZkBobAccounting: non-existing pool limits tier");
+        for (uint256 i = 0; i < _users.length; i++) {
+            address user = _users[i];
+            userStats[user].tier = _tier;
+            emit UpdateTier(user, _tier);
+        }
     }
 
     function _txCount() internal view returns (uint256) {

--- a/test/mocks/ZkBobAccountingMock.sol
+++ b/test/mocks/ZkBobAccountingMock.sol
@@ -20,7 +20,14 @@ contract ZkBobAccountingMock is ZkBobAccounting {
         (weekMaxTvl, weekMaxCount, txCount) = _recordOperation(msg.sender, _amount / 1 gwei);
     }
 
+    function setUserTier(uint8 _tier, address _user) external {
+        address[] memory users = new address[](1);
+        users[0] = _user;
+        _setUsersTier(_tier, users);
+    }
+
     function setLimits(
+        uint8 _tier,
         uint256 _tvlCap,
         uint256 _dailyDepositCap,
         uint256 _dailyWithdrawalCap,
@@ -30,6 +37,7 @@ contract ZkBobAccountingMock is ZkBobAccounting {
         external
     {
         _setLimits(
+            _tier,
             _tvlCap / 1 gwei,
             _dailyDepositCap / 1 gwei,
             _dailyWithdrawalCap / 1 gwei,

--- a/test/zkbob/utils/ZkBobAccounting.t.sol
+++ b/test/zkbob/utils/ZkBobAccounting.t.sol
@@ -12,7 +12,7 @@ contract ZkBobAccountingTest is Test {
     function setUp() public {
         pool = new ZkBobAccountingMock();
 
-        pool.setLimits(1000 ether, 1000 ether, 1000 ether, 1000 ether, 1000 ether);
+        pool.setLimits(0, 1000 ether, 1000 ether, 1000 ether, 1000 ether, 1000 ether);
 
         vm.warp(1000 weeks);
     }
@@ -124,7 +124,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDepositCap() public {
-        pool.setLimits(1000 ether, 500 ether, 500 ether, 300 ether, 100 ether);
+        pool.setLimits(0, 1000 ether, 500 ether, 500 ether, 300 ether, 100 ether);
 
         vm.expectRevert("ZkBobAccounting: single deposit cap exceeded");
         pool.transact(200 ether);
@@ -133,7 +133,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyUserDepositCap() public {
-        pool.setLimits(1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
+        pool.setLimits(0, 1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
 
         pool.transact(100 ether);
         pool.transact(100 ether);
@@ -142,7 +142,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyDepositCap() public {
-        pool.setLimits(1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
+        pool.setLimits(0, 1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
 
         pool.transact(100 ether);
         pool.transact(100 ether);
@@ -160,7 +160,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testTvlCap() public {
-        pool.setLimits(1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
+        pool.setLimits(0, 1000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
 
         for (uint256 i = 0; i < 10; i++) {
             pool.transact(100 ether);
@@ -172,7 +172,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyUserDepositCapReset() public {
-        pool.setLimits(10000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
+        pool.setLimits(0, 10000 ether, 500 ether, 500 ether, 200 ether, 100 ether);
 
         for (uint256 i = 0; i < 5; i++) {
             pool.transact(100 ether);
@@ -185,7 +185,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyDepositCapReset() public {
-        pool.setLimits(10000 ether, 500 ether, 500 ether, 300 ether, 150 ether);
+        pool.setLimits(0, 10000 ether, 500 ether, 500 ether, 300 ether, 150 ether);
 
         for (uint256 i = 0; i < 5; i++) {
             pool.transact(150 ether);
@@ -208,7 +208,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyWithdrawalCap() public {
-        pool.setLimits(1000 ether, 500 ether, 300 ether, 200 ether, 100 ether);
+        pool.setLimits(0, 1000 ether, 500 ether, 300 ether, 200 ether, 100 ether);
 
         for (uint256 i = 0; i < 10; i++) {
             pool.transact(100 ether);
@@ -228,7 +228,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testDailyWithdrawalCapReset() public {
-        pool.setLimits(10000 ether, 500 ether, 500 ether, 300 ether, 100 ether);
+        pool.setLimits(0, 10000 ether, 500 ether, 500 ether, 300 ether, 100 ether);
 
         for (uint256 i = 0; i < 100; i++) {
             pool.transact(100 ether);
@@ -256,7 +256,7 @@ contract ZkBobAccountingTest is Test {
     }
 
     function testGetLimitsFor() public {
-        pool.setLimits(10000 ether, 500 ether, 400 ether, 300 ether, 150 ether);
+        pool.setLimits(0, 10000 ether, 500 ether, 400 ether, 300 ether, 150 ether);
 
         ZkBobAccounting.Limits memory limits1;
         ZkBobAccounting.Limits memory limits2;
@@ -298,8 +298,8 @@ contract ZkBobAccountingTest is Test {
         assertEq(limits2.tvl, 210 gwei);
         assertEq(limits2.dailyDepositCap, 500 gwei);
         assertEq(limits2.dailyDepositCapUsage, 220 gwei);
-        assertEq(limits1.dailyWithdrawalCap, 400 gwei);
-        assertEq(limits1.dailyWithdrawalCapUsage, 10 gwei);
+        assertEq(limits2.dailyWithdrawalCap, 400 gwei);
+        assertEq(limits2.dailyWithdrawalCapUsage, 10 gwei);
         assertEq(limits2.dailyUserDepositCap, 300 gwei);
         assertEq(limits2.dailyUserDepositCapUsage, 100 gwei);
         assertEq(limits2.depositCap, 150 gwei);
@@ -322,10 +322,92 @@ contract ZkBobAccountingTest is Test {
         assertEq(limits2.tvl, 210 gwei);
         assertEq(limits2.dailyDepositCap, 500 gwei);
         assertEq(limits2.dailyDepositCapUsage, 0 gwei);
-        assertEq(limits1.dailyWithdrawalCap, 400 gwei);
-        assertEq(limits1.dailyWithdrawalCapUsage, 0 gwei);
+        assertEq(limits2.dailyWithdrawalCap, 400 gwei);
+        assertEq(limits2.dailyWithdrawalCapUsage, 0 gwei);
         assertEq(limits2.dailyUserDepositCap, 300 gwei);
         assertEq(limits2.dailyUserDepositCapUsage, 0 gwei);
         assertEq(limits2.depositCap, 150 gwei);
+    }
+
+    function testPoolLimitsTiers() public {
+        pool.setLimits(0, 600 ether, 500 ether, 400 ether, 300 ether, 150 ether);
+        pool.setLimits(1, 10000 ether, 1000 ether, 800 ether, 600 ether, 300 ether);
+
+        pool.setUserTier(1, user2);
+        vm.expectRevert("ZkBobAccounting: non-existing pool limits tier");
+        pool.setUserTier(2, user3);
+        pool.setUserTier(255, user3);
+
+        // TVL == 0
+
+        vm.prank(user1);
+        pool.transact(100 ether);
+        vm.prank(user2);
+        pool.transact(100 ether);
+        vm.prank(user3);
+        vm.expectRevert("ZkBobAccounting: single deposit cap exceeded");
+        pool.transact(100 ether);
+
+        // TVL == 200
+
+        vm.prank(user1);
+        vm.expectRevert("ZkBobAccounting: single deposit cap exceeded");
+        pool.transact(200 ether);
+        vm.prank(user2);
+        pool.transact(200 ether);
+
+        // TVL == 400
+
+        vm.prank(user1);
+        vm.expectRevert("ZkBobAccounting: daily deposit cap exceeded");
+        pool.transact(150 ether);
+        vm.prank(user2);
+        pool.transact(150 ether);
+
+        // TVL == 550
+
+        vm.prank(user1);
+        vm.expectRevert("ZkBobAccounting: tvl cap exceeded");
+        pool.transact(150 ether);
+        vm.prank(user2);
+        pool.transact(150 ether);
+
+        // TVL == 700
+
+        ZkBobAccounting.Limits memory limits1 = pool.getLimitsFor(user1);
+        assertEq(limits1.tvlCap, 600 gwei);
+        assertEq(limits1.tvl, 700 gwei);
+        assertEq(limits1.dailyDepositCap, 500 gwei);
+        assertEq(limits1.dailyDepositCapUsage, 700 gwei);
+        assertEq(limits1.dailyWithdrawalCap, 400 gwei);
+        assertEq(limits1.dailyWithdrawalCapUsage, 0 gwei);
+        assertEq(limits1.dailyUserDepositCap, 300 gwei);
+        assertEq(limits1.dailyUserDepositCapUsage, 100 gwei);
+        assertEq(limits1.depositCap, 150 gwei);
+        assertEq(limits1.tier, 0);
+
+        ZkBobAccounting.Limits memory limits2 = pool.getLimitsFor(user2);
+        assertEq(limits2.tvlCap, 10000 gwei);
+        assertEq(limits2.tvl, 700 gwei);
+        assertEq(limits2.dailyDepositCap, 1000 gwei);
+        assertEq(limits2.dailyDepositCapUsage, 700 gwei);
+        assertEq(limits2.dailyWithdrawalCap, 800 gwei);
+        assertEq(limits2.dailyWithdrawalCapUsage, 0 gwei);
+        assertEq(limits2.dailyUserDepositCap, 600 gwei);
+        assertEq(limits2.dailyUserDepositCapUsage, 600 gwei);
+        assertEq(limits2.depositCap, 300 gwei);
+        assertEq(limits2.tier, 1);
+
+        ZkBobAccounting.Limits memory limits3 = pool.getLimitsFor(user3);
+        assertEq(limits3.tvlCap, 0 gwei);
+        assertEq(limits3.tvl, 700 gwei);
+        assertEq(limits3.dailyDepositCap, 0 gwei);
+        assertEq(limits3.dailyDepositCapUsage, 700 gwei);
+        assertEq(limits3.dailyWithdrawalCap, 0 gwei);
+        assertEq(limits3.dailyWithdrawalCapUsage, 0 gwei);
+        assertEq(limits3.dailyUserDepositCap, 0 gwei);
+        assertEq(limits3.dailyUserDepositCapUsage, 0 gwei);
+        assertEq(limits3.depositCap, 0 gwei);
+        assertEq(limits3.tier, 255);
     }
 }


### PR DESCRIPTION
# Summary

This PR introduces 256 dynamic pool limit tiers, configurable by the pool owner.
* `0` - is the default pool limits tier, assigned to any unknown user.
* `1-254` - are pool limits that might be assigned by the owner to well-known users with sufficient off-chain KYC requirements.
* `255` - pool limits tier, that completely prohibits interaction with the pool from the specified address.

Pool limits for specific tier could be set/updated by calling the `setLimits(...)` function.

Users tiers could be updated by calling the `setUsersTiers(...)` function.

# Edge cases

As it now becomes possible for different users to have different limits, `getLimitsFor(...)` function might returns usage values higher than specific limits of the particular lower tier user.

It might be now the case, that during high deposit/withdrawal activity, only higher-tier users will be able to interact with the pool till the end of a day, after the lower-tier limit is fully used.

UI and relayer should handle these cases accordingly.

# Possible upgrade procedure

1. Deploy `ZkBobPool` contract implementation with the same constructor parameters as before (https://polygonscan.com/address/0x869e31b25f9c84354fe962cec2a0ec1468476925#code):
  a. `__pool_id` is 0
  b. `_token` is [0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b](https://polygonscan.com/address/0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b)
  c. `_transfer_verifier` is [0x51585f5af7b5f0bbf7f91fe8919fbff362a2fd95](https://polygonscan.com/address/0x51585f5af7b5f0bbf7f91fe8919fbff362a2fd95)
  d. `_tree_verifier` is [0x82907eaeb25d248dc82033e45b00a3e012ba2d0d](https://polygonscan.com/address/0x82907eaeb25d248dc82033e45b00a3e012ba2d0d)
2. Call `upgradeTo(<ZkBobPool>)` from a governance multisig.
3. Call `setLimits(0, 1_000_000 ether, 100_000 ether, 100_000 ether, 10_000 ether, 10_000 ether)` from a governance multisig to reinitialise the default limits (note the `Slot2` to `mapping(uint256 => PoolLimits)` change in the storage layout)

Steps 2 and 3 can be done as part of a single batch transaction.