### PR TITLE
Add tests for AAVE V3 integration

### DIFF
--- a/src/interfaces/ILendingPool.sol
+++ b/src/interfaces/ILendingPool.sol
@@ -23,5 +23,5 @@ interface ILendingPool {
 
     // workaround to omit usage of abicoder v2
     // see real signature at https://github.com/aave/protocol-v2/blob/master/contracts/protocol/libraries/types/DataTypes.sol
-    function getReserveData(address asset) external returns (address[12] memory);
+    function getReserveData(address asset) external returns (uint256[12] memory);
 }

--- a/src/yield/AAVEYieldImplementation.sol
+++ b/src/yield/AAVEYieldImplementation.sol
@@ -11,7 +11,7 @@ import "../interfaces/IYieldImplementation.sol";
 
 /**
  * @title AAVEYieldImplementation
- * @dev This contract contains token-specific logic for investing ERC20 tokens into AAVE V2 protocol.
+ * @dev This contract contains token-specific logic for investing ERC20 tokens into AAVE V2/V3 protocol.
  */
 contract AAVEYieldImplementation is IYieldImplementation {
     using SafeERC20 for IERC20;
@@ -28,7 +28,9 @@ contract AAVEYieldImplementation is IYieldImplementation {
     }
 
     function initialize(address _token) external {
-        address aToken = lendingPool.getReserveData(_token)[7];
+        uint256[12] memory reserveData = lendingPool.getReserveData(_token);
+        // 7th slot for AAVE v2, 8th slot for AAVE v3
+        address aToken = address(uint160(reserveData[reserveData[7] <= type(uint16).max ? 8 : 7]));
         require(IAToken(aToken).UNDERLYING_ASSET_ADDRESS() == _token);
         interestToken[_token] = aToken;
 

--- a/test/BobVault.t.sol
+++ b/test/BobVault.t.sol
@@ -73,6 +73,20 @@ contract BobVaultTest is Test, EIP2470Test {
         vm.label(address(dai), "DAI");
     }
 
+    function _forkOptimism() internal {
+        usdc = IERC20(0x7F5c764cBc14f9669B88837ca1490cCa17c31607);
+        usdt = IERC20(0x94b008aA00579c1307B0EF2c499aD98a8ce58e58);
+        dai = IERC20(0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1);
+
+        vm.createSelectFork(forkRpcUrlOptimism);
+
+        _forkApprovals();
+
+        vm.label(address(usdc), "USDC");
+        vm.label(address(usdt), "USDT");
+        vm.label(address(dai), "DAI");
+    }
+
     function _forkApprovals() internal {
         deal(address(usdc), deployer, 1e12 * 1e6);
         deal(address(usdt), deployer, 1e12 * 1e6);
@@ -412,6 +426,12 @@ contract BobVaultTest is Test, EIP2470Test {
 
     function testAAVEv3Polygon() public {
         _forkPolygon();
+
+        _testAAVEIntegration(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
+    }
+
+    function testAAVEv3Optimism() public {
+        _forkOptimism();
 
         _testAAVEIntegration(0x794a61358D6845594F94dc1DB02A252b5b4814aD);
     }

--- a/test/shared/Env.t.sol
+++ b/test/shared/Env.t.sol
@@ -16,7 +16,8 @@ address constant mockImpl = address(0xdead);
 address constant bobVanityAddr = address(0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B);
 bytes32 constant bobSalt = bytes32(uint256(285834900769));
 
-string constant forkRpcUrl = "https://rpc.ankr.com/eth";
+string constant forkRpcUrlMainnet = "https://rpc.ankr.com/eth";
+string constant forkRpcUrlPolygon = "https://polygon-rpc.com";
 
 address constant uniV3Router = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
 address constant uniV3Quoter = 0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6;

--- a/test/shared/Env.t.sol
+++ b/test/shared/Env.t.sol
@@ -18,6 +18,7 @@ bytes32 constant bobSalt = bytes32(uint256(285834900769));
 
 string constant forkRpcUrlMainnet = "https://rpc.ankr.com/eth";
 string constant forkRpcUrlPolygon = "https://polygon-rpc.com";
+string constant forkRpcUrlOptimism = "https://rpc.ankr.com/optimism";
 
 address constant uniV3Router = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
 address constant uniV3Quoter = 0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6;

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -101,7 +101,7 @@ contract ZkBobPoolTest is Test {
         );
 
         // fork mainnet
-        vm.createSelectFork(forkRpcUrl);
+        vm.createSelectFork(forkRpcUrlMainnet);
 
         // create BOB-USDC 0.05% pool at Uniswap V3
         deal(usdc, address(this), 1e9);


### PR DESCRIPTION
AAVE V3 uses the same interface as AAVE V2 for all external operations, so it should be pretty straightforward to integrate either of them in BobVault.

Additional fork tests also ensure proper functioning of the lending integration in across multiple AAVE markets in different chains.