### PR TITLE
Configurable pool id for deployment scripts

### DIFF
--- a/script/scripts/Env.s.sol
+++ b/script/scripts/Env.s.sol
@@ -16,6 +16,7 @@ address constant bobVanityAddr = address(0xB0B195aEFA3650A6908f15CdaC7D92F8a5791
 bytes32 constant bobSalt = bytes32(uint256(285834900769));
 
 // zkbob
+uint256 constant zkBobPoolId = 0; // 0 is reserved for Polygon MVP pool, do not use for other deployments
 string constant zkBobVerifiers = "prodV1";
 uint256 constant zkBobInitialRoot = 11469701942666298368112882412133877458305516134926649826543144744382391691533;
 address constant zkBobRelayer = 0xc2c4AD59B78F4A0aFD0CDB8133E640Db08Fa5b90;
@@ -37,6 +38,7 @@ uint64 constant vaultCollateralOutFee = 0;
 address constant vaultCollateralAAVELendingPool = 0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf;
 uint128 constant vaultCollateralBuffer = 1_000_000 * 1_000_000;
 uint96 constant vaultCollateralDust = 1_000_000;
+
 // bob seller
 address constant uniV3Router = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
 address constant uniV3Quoter = 0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6;

--- a/script/scripts/Local.s.sol
+++ b/script/scripts/Local.s.sol
@@ -35,7 +35,7 @@ contract DeployLocal is Script {
         }
 
         ZkBobPool poolImpl = new ZkBobPool(
-            0,
+            zkBobPoolId,
             address(bob),
             transferVerifier,
             treeVerifier

--- a/script/scripts/ZkBobPool.s.sol
+++ b/script/scripts/ZkBobPool.s.sol
@@ -24,7 +24,7 @@ contract DeployZkBobPool is Script {
         }
 
         ZkBobPool impl = new ZkBobPool(
-            0,
+            zkBobPoolId,
             bobVanityAddr,
             transferVerifier,
             treeVerifier


### PR DESCRIPTION
Add explicitly configurable pool id for future deployments. In order to avoid accidental replay attacks, future deployments should use a different pool id from the Polygon zkBob pool (e.g. new Goerli staging deployment).