### PR TITLE
Fix daily limits reset

### DIFF
--- a/script/scripts/Env.s.sol
+++ b/script/scripts/Env.s.sol
@@ -28,6 +28,9 @@ uint256 constant zkBobDailyWithdrawalCap = 100_000 ether;
 uint256 constant zkBobDailyUserDepositCap = 10_000 ether;
 uint256 constant zkBobDepositCap = 10_000 ether;
 
+// new zkbob impl
+address constant zkBobPool = 0x72e6B59D4a90ab232e55D4BB7ed2dD17494D62fB;
+
 // vault
 address constant vaultYieldAdmin = 0x0000000000000000000000000000000000000000;
 address constant vaultInvestAdmin = 0x0000000000000000000000000000000000000000;

--- a/script/scripts/NewZkBobPoolImpl.s.sol
+++ b/script/scripts/NewZkBobPoolImpl.s.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.8.15;
+
+import "forge-std/Script.sol";
+import "./Env.s.sol";
+import "../../src/proxy/EIP1967Proxy.sol";
+import "../../src/zkbob/ZkBobPool.sol";
+import "../../src/zkbob/manager/MutableOperatorManager.sol";
+
+contract DeployNewZkBobPoolImpl is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        ZkBobPool pool = ZkBobPool(zkBobPool);
+
+        ZkBobPool impl = new ZkBobPool(
+            pool.pool_id(),
+            pool.token(),
+            pool.transfer_verifier(),
+            pool.tree_verifier()
+        );
+
+        vm.stopBroadcast();
+
+        console2.log("ZkBobPool implementation:", address(impl));
+    }
+}

--- a/src/zkbob/ZkBobPool.sol
+++ b/src/zkbob/ZkBobPool.sol
@@ -279,6 +279,14 @@ contract ZkBobPool is EIP1967Admin, Ownable, Parameters, ZkBobAccounting {
     }
 
     /**
+     * @dev Resets daily limit usage for the current day.
+     * Callable only by the contract owner / proxy admin.
+     */
+    function resetDailyLimits() external onlyOwner {
+        _resetDailyLimits();
+    }
+
+    /**
      * @dev Updates users limit tiers.
      * Callable only by the contract owner / proxy admin.
      * @param _tier pool limits tier (0-255).


### PR DESCRIPTION
The current codebase contains a bug that prevents proper daily deposit/withdrawal limit reset during a new day transition:
1. When the new day starts with a deposit operation, only daily deposit limit would be reset
2. When the new day starts with a withdrawal operation, only daily withdrawal limit would be reset
3. When the new day starts with a transfer operation, none of the daily limits would be reset

This PR fixes that and adds a regression test.