### PR TITLE
Emit missing events on important configuration changes

### DIFF
--- a/src/zkbob/ZkBobPool.sol
+++ b/src/zkbob/ZkBobPool.sol
@@ -43,6 +43,8 @@ contract ZkBobPool is EIP1967Admin, Ownable, Parameters, ZkBobAccounting {
 
     ITokenSeller public tokenSeller;
 
+    event UpdateTokenSeller(address seller);
+
     event Message(uint256 indexed index, bytes32 indexed hash, bytes message);
 
     constructor(uint256 __pool_id, address _token, ITransferVerifier _transfer_verifier, ITreeVerifier _tree_verifier) {
@@ -102,6 +104,7 @@ contract ZkBobPool is EIP1967Admin, Ownable, Parameters, ZkBobAccounting {
      */
     function setTokenSeller(address _seller) external onlyOwner {
         tokenSeller = ITokenSeller(_seller);
+        emit UpdateTokenSeller(_seller);
     }
 
     /**

--- a/src/zkbob/manager/MutableOperatorManager.sol
+++ b/src/zkbob/manager/MutableOperatorManager.sol
@@ -18,6 +18,8 @@ contract MutableOperatorManager is IOperatorManager, Ownable {
     // current operator public API URL
     string public operatorURI;
 
+    event UpdateOperator(address indexed operator, address feeReceiver, string operatorURI);
+
     constructor(address _operator, address _feeReceiver, string memory _operatorURI) Ownable() {
         _setOperator(_operator, _feeReceiver, _operatorURI);
     }
@@ -36,6 +38,8 @@ contract MutableOperatorManager is IOperatorManager, Ownable {
         }
         operator = _operator;
         operatorURI = _operatorURI;
+
+        emit UpdateOperator(_operator, _feeReceiver, _operatorURI);
     }
 
     function isOperator(address _addr) external view override returns (bool) {

--- a/src/zkbob/utils/ZkBobAccounting.sol
+++ b/src/zkbob/utils/ZkBobAccounting.sol
@@ -97,6 +97,7 @@ contract ZkBobAccounting {
     mapping(uint256 => Snapshot) private snapshots; // single linked list of hourly snapshots
     mapping(address => UserStats) private userStats;
 
+    event UpdateLimits(uint8 indexed tier, PoolLimits limits);
     event UpdateTier(address user, uint8 tier);
 
     /**
@@ -252,13 +253,15 @@ contract ZkBobAccounting {
         require(_dailyDepositCap >= _dailyUserDepositCap, "ZkBobAccounting: daily deposit cap too low");
         require(_tvlCap >= _dailyDepositCap, "ZkBobAccounting: tvl cap too low");
         require(_dailyWithdrawalCap > 0, "ZkBobAccounting: zero daily withdrawal cap");
-        poolLimits[_tier] = PoolLimits({
+        PoolLimits memory pl = PoolLimits({
             tvlCap: uint56(_tvlCap / PRECISION),
             dailyDepositCap: uint32(_dailyDepositCap / PRECISION),
             dailyWithdrawalCap: uint32(_dailyWithdrawalCap / PRECISION),
             dailyUserDepositCap: uint32(_dailyUserDepositCap / PRECISION),
             depositCap: uint32(_depositCap / PRECISION)
         });
+        poolLimits[_tier] = pl;
+        emit UpdateLimits(_tier, pl);
     }
 
     function _setUsersTier(uint8 _tier, address[] memory _users) internal {


### PR DESCRIPTION
Many state-changing operations do not emit events. Consider emitting events for important state
changes.
These operations include:
`ZkBobPool`:
  - `initialize()`
  - `setTokenSeller()`
  - `setOperatorManager()`
 
`ZkBobAccounting`:
  - `_setLimits()`
  - `_resetDailyLimits()`
  - `_setUsersTier()`

`BobVault:`
  - `setYieldAdmin()`
  - `setInvestAdmin()`

`MutableOperatorManager`:
  - `_setOperator()`

`ERC20Recovery`:
  - `setRecoveryAdmin()`
  - `setRecoveredFundsReceiver()`
  - `setRecoveryLimitPercent()`
  - `setRecoveryRequestTimelockPeriod()`

`Claimable`:
  - `setClaimingAdmin()`

_Comments to changes:_
Event describing the corresponding changes were added to:
  - `ZkBobPool`: `setTokenSeller()`, `setOperatorManager()`, `withdrawFee()`
  - `ZkBobAccounting`: `_setLimits()`
  - `MutableOperatorManager`: `_setOperator()`

. For other parameters, they are not expected to be changed regularly and there is no any interest in their retrospective observations, thus such events considered as redundant:
  - `ZkBobPool`: `initialize()` – an event will be emitted as part of _setLimits execution
  - `ZkBobAccounting`: `_resetDailyLimits()` is not expected to be called regularly; _setUsersTier() already contains the event `UpdateTier`
  - `BobVault`: `setYieldAdmin()` and `setInvestAdmin()` are not expected to be called regularly
  - `ERC20Recovery: `setRecoveryAdmin()` is not expected to be called regularly; `setRecoveredFundsReceiver()`, `setRecoveryLimitPercent()`, `setRecoveryRequestTimelockPeriod()` do not require their retrospective observations whereas the current value can be extracted with getters.
  - `Claimable`: `setClaimingAdmin()` is not expected to be called regularly
