### PR TITLE
Renounce BobVault implementation ownership in constructor

### DIFF
--- a/src/BobVault.sol
+++ b/src/BobVault.sol
@@ -58,6 +58,7 @@ contract BobVault is EIP1967Admin, Ownable, YieldConnector {
 
     constructor(address _bobToken) {
         bobToken = IERC20(_bobToken);
+        _transferOwnership(address(0));
     }
 
     /**

--- a/test/BobVault.t.sol
+++ b/test/BobVault.t.sol
@@ -124,9 +124,9 @@ contract BobVaultTest is Test, EIP2470Test {
 
         bob.mint(address(vault), _bobAmount);
 
-        usdc.transfer(user1, 10000000);
-        ILegacyERC20(address(usdt)).transfer(user1, 10000000);
-        dai.transfer(user1, 10 ether);
+        deal(address(usdc), user1, 10000000);
+        deal(address(usdt), user1, 10000000);
+        deal(address(dai), user1, 10 ether);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
BobVault implementation contract contains several delegate-calls to addresses configured by owner, thus keeping a non-zero owner address in the implementation contract is not safe, as the owner can execute a delegated self-destruct.

The safest option would be to renounce ownership of the implementation contract in the constructor.