### PR TITLE
Forbid deposit transactions with negative token delta

### DIFF
--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -41,7 +41,7 @@ contract ZkBobPoolTest is Test {
     }
 
     function testSimpleTransaction() public {
-        bytes memory data1 = _encodePermitDeposit(0.5 ether);
+        bytes memory data1 = _encodePermitDeposit(0.5 ether, 0.01 ether);
         _transact(data1);
 
         bytes memory data2 = _encodeTransfer();
@@ -53,7 +53,7 @@ contract ZkBobPoolTest is Test {
     }
 
     function testPermitDeposit() public {
-        bytes memory data = _encodePermitDeposit(0.5 ether);
+        bytes memory data = _encodePermitDeposit(0.5 ether, 0.01 ether);
         _transact(data);
 
         vm.prank(user3);
@@ -67,7 +67,7 @@ contract ZkBobPoolTest is Test {
         vm.prank(user1);
         bob.approve(address(pool), 0.51 ether);
 
-        bytes memory data = _encodeDeposit(0.5 ether);
+        bytes memory data = _encodeDeposit(0.5 ether, 0.01 ether);
         _transact(data);
 
         vm.prank(user3);
@@ -78,7 +78,7 @@ contract ZkBobPoolTest is Test {
     }
 
     function testWithdrawal() public {
-        bytes memory data1 = _encodePermitDeposit(0.5 ether);
+        bytes memory data1 = _encodePermitDeposit(0.5 ether, 0.01 ether);
         _transact(data1);
 
         bytes memory data2 = _encodeWithdrawal(user1, 0.1 ether, 0 ether);
@@ -145,7 +145,7 @@ contract ZkBobPoolTest is Test {
 
         vm.deal(user1, 0);
 
-        bytes memory data1 = _encodePermitDeposit(0.99 ether);
+        bytes memory data1 = _encodePermitDeposit(0.99 ether, 0.01 ether);
         _transact(data1);
 
         // user1 withdraws 0.4 BOB, 0.3 BOB gets converted to ETH
@@ -177,7 +177,7 @@ contract ZkBobPoolTest is Test {
 
         vm.deal(user1, 0);
 
-        bytes memory data1 = _encodePermitDeposit(10000 ether);
+        bytes memory data1 = _encodePermitDeposit(10000 ether, 0.01 ether);
         _transact(data1);
 
         uint256 quote2 = pool.tokenSeller().quoteSellForETH(60 ether);
@@ -203,13 +203,28 @@ contract ZkBobPoolTest is Test {
         assertEq(user1.balance, quote2 + quote31);
     }
 
-    function _encodePermitDeposit(uint256 _amount) internal returns (bytes memory) {
+    function testRejectNegativeDeposits() public {
+        bytes memory data1 = _encodePermitDeposit(0.99 ether, 0.01 ether);
+        _transact(data1);
+
+        bytes memory data2 = _encodePermitDeposit(-0.5 ether, 1 ether);
+        _transactReverted(data2, "ZkBobPool: incorrect deposit amounts");
+
+        vm.prank(user1);
+        bob.approve(address(pool), 0.5 ether);
+
+        bytes memory data3 = _encodeDeposit(-0.5 ether, 1 ether);
+        _transactReverted(data3, "ZkBobPool: incorrect deposit amounts");
+    }
+
+    function _encodePermitDeposit(int256 _amount, uint256 _fee) internal returns (bytes memory) {
         uint256 expiry = block.timestamp + 1 hours;
         bytes32 nullifier = bytes32(_randFR());
-        (uint8 v, bytes32 r, bytes32 s) =
-            _signSaltedPermit(pk1, user1, address(pool), _amount + 0.01 ether, bob.nonces(user1), expiry, nullifier);
+        (uint8 v, bytes32 r, bytes32 s) = _signSaltedPermit(
+            pk1, user1, address(pool), uint256(_amount + int256(_fee)), bob.nonces(user1), expiry, nullifier
+        );
         bytes memory data = abi.encodePacked(
-            ZkBobPool.transact.selector, nullifier, _randFR(), uint48(0), uint112(0), int64(int256(_amount / 1 gwei))
+            ZkBobPool.transact.selector, nullifier, _randFR(), uint48(0), uint112(0), int64(_amount / 1 gwei)
         );
         for (uint256 i = 0; i < 17; i++) {
             data = abi.encodePacked(data, _randFR());
@@ -218,7 +233,7 @@ contract ZkBobPoolTest is Test {
             data,
             uint16(3),
             uint16(80),
-            uint64(0.01 ether / 1 gwei),
+            uint64(_fee / 1 gwei),
             uint64(expiry),
             user1,
             bytes32(_randFR()),
@@ -227,18 +242,17 @@ contract ZkBobPoolTest is Test {
         return abi.encodePacked(data, r, uint256(s) + (v == 28 ? (1 << 255) : 0));
     }
 
-    function _encodeDeposit(uint256 _amount) internal returns (bytes memory) {
+    function _encodeDeposit(int256 _amount, uint256 _fee) internal returns (bytes memory) {
         bytes32 nullifier = bytes32(_randFR());
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk1, ECDSA.toEthSignedMessageHash(nullifier));
         bytes memory data = abi.encodePacked(
-            ZkBobPool.transact.selector, nullifier, _randFR(), uint48(0), uint112(0), int64(int256(_amount / 1 gwei))
+            ZkBobPool.transact.selector, nullifier, _randFR(), uint48(0), uint112(0), int64(_amount / 1 gwei)
         );
         for (uint256 i = 0; i < 17; i++) {
             data = abi.encodePacked(data, _randFR());
         }
-        data = abi.encodePacked(
-            data, uint16(0), uint16(48), uint64(0.01 ether / 1 gwei), _randFR(), bytes8(bytes32(_randFR()))
-        );
+        data =
+            abi.encodePacked(data, uint16(0), uint16(48), uint64(_fee / 1 gwei), _randFR(), bytes8(bytes32(_randFR())));
         return abi.encodePacked(data, r, uint256(s) + (v == 28 ? (1 << 255) : 0));
     }
 
@@ -282,6 +296,13 @@ contract ZkBobPoolTest is Test {
         vm.prank(user2);
         (bool status,) = address(pool).call(_data);
         require(status, "transact() reverted");
+    }
+
+    function _transactReverted(bytes memory _data, bytes memory _revertReason) internal {
+        vm.prank(user2);
+        (bool status, bytes memory returnData) = address(pool).call(_data);
+        assert(!status);
+        assertEq(returnData, abi.encodeWithSignature("Error(string)", _revertReason));
     }
 
     function _signSaltedPermit(


### PR DESCRIPTION
For the deposit transactions, there is an unlikely case with relayer fee being larger than deposited amount.
Such transactions don't make any sense for the signing user, cannot be generated via UI and SDK, but introduce unnecessary confusion, as highlighted during the audit.

This PR replaces deposit amounts validation checks with a stricter alternative, which also ensures that deposit fee is lower than deposit amount.