### PR TITLE
Fix permit-related issues

### DIFF
--- a/src/interfaces/IERC20Permit.sol
+++ b/src/interfaces/IERC20Permit.sol
@@ -32,18 +32,6 @@ interface IERC20Permit {
     )
         external;
 
-    function saltedPermit(
-        address _holder,
-        address _spender,
-        uint256 _value,
-        uint256 _deadline,
-        bytes32 _salt,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    )
-        external;
-
     function receiveWithSaltedPermit(
         address _holder,
         uint256 _value,

--- a/src/token/ERC20Permit.sol
+++ b/src/token/ERC20Permit.sol
@@ -76,28 +76,9 @@ abstract contract ERC20Permit is IERC20Permit, BaseERC20, EIP712 {
         // we don't make calls to _approve to avoid unnecessary storage writes
         // however, emitting ERC20 events is still desired
         emit Approval(_holder, msg.sender, _value);
-        emit Approval(_holder, msg.sender, 0);
 
+        _approve(_holder, msg.sender, 0);
         _transfer(_holder, msg.sender, _value);
-    }
-
-    /**
-     * @dev Salted permit modification.
-     */
-    function saltedPermit(
-        address _holder,
-        address _spender,
-        uint256 _value,
-        uint256 _deadline,
-        bytes32 _salt,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    )
-        external
-    {
-        _checkSaltedPermit(_holder, _spender, _value, _deadline, _salt, _v, _r, _s);
-        _approve(_holder, _spender, _value);
     }
 
     /**
@@ -120,8 +101,8 @@ abstract contract ERC20Permit is IERC20Permit, BaseERC20, EIP712 {
         // we don't make calls to _approve to avoid unnecessary storage writes
         // however, emitting ERC20 events is still desired
         emit Approval(_holder, msg.sender, _value);
-        emit Approval(_holder, msg.sender, 0);
 
+        _approve(_holder, msg.sender, 0);
         _transfer(_holder, msg.sender, _value);
     }
 

--- a/src/token/ERC20Permit.sol
+++ b/src/token/ERC20Permit.sol
@@ -32,6 +32,9 @@ abstract contract ERC20Permit is IERC20Permit, BaseERC20, EIP712 {
      * @dev Allows to spend holder's unlimited amount by the specified spender according to EIP2612.
      * The function can be called by anyone, but requires having allowance parameters
      * signed by the holder according to EIP712.
+     * Note: call to permit can be executed in the front-running transaction sent by other party,
+     * contracts using permit/receiveWithPermit are advised to implement necessary fallbacks for failing permit calls,
+     * avoiding entire transaction failures if possible.
      * @param _holder The holder's address.
      * @param _spender The spender's address.
      * @param _value Allowance value to set as a result of the call.
@@ -59,6 +62,9 @@ abstract contract ERC20Permit is IERC20Permit, BaseERC20, EIP712 {
 
     /**
      * @dev Cheap shortcut for making sequential calls to permit() + transferFrom() functions.
+     * Note: signatures from receiveWithPermit can be re-used in the front-running permit transaction sent by other party,
+     * contracts using permit/receiveWithPermit are advised to implement necessary fallbacks for failing
+     * receiveWithPermit calls, avoiding entire transaction failures if possible.
      */
     function receiveWithPermit(
         address _holder,

--- a/src/zkbob/utils/CustomABIDecoder.sol
+++ b/src/zkbob/utils/CustomABIDecoder.sol
@@ -175,7 +175,7 @@ contract CustomABIDecoder {
         r = address(uint160(_loaduint256(memo_receiver_pos + memo_receiver_size - uint256_size)));
     }
 
-    // Peermittable token deposit specific data
+    // Permittable token deposit specific data
 
     uint256 constant memo_permit_deadline_pos = memo_fee_pos + memo_fee_size;
     uint256 constant memo_permit_deadline_size = 8;


### PR DESCRIPTION
The `ZkBobPool` permittable deposit relies on the `ERC20Permit.receiveWithSaltedPermit` function. However, the signature used in this function can be used in the `ERC20Permit.saltedPermit` function as well. An attacker can intercept the deposit transaction, extract the signature and use it in the call to `saltedPermit`. As a result of this action, the permittable deposit will fail due to the nonce already having been used.

In regular use-cases for permit, a typical fallback would work perfectly fine. However, in case of `ZkBobPool` permittable deposit processing, extra logic assigned for salt signature validation (which was the original reason behind introducing salted permits) prevents us from implementing such kind of fallback.

The simplest solution would be to remove regular `saltedPermit` function, as it is non used by anyone at the moment.

The same front-running issue is applicable to `permit` and `receiveWithPermit` functions. We are not using regular ERC2612 permits in ZkBob, but all third-party integrators relying on `permit`/`receiveWithPermit` are advised to implement necessary fallbacks for failing `permit`/`receiveWithPermit` calls, avoiding entire transaction failures. 