### PR TITLE
Add sanity checks on uint conversion limits

### DIFF
--- a/src/BobVault.sol
+++ b/src/BobVault.sol
@@ -369,7 +369,10 @@ contract BobVault is EIP1967Admin, Ownable, YieldConnector {
         uint256 fee = _amount * uint256(token.inFee) / 1 ether;
         uint256 sellAmount = _amount - fee;
         uint256 buyAmount = sellAmount * 1 ether / token.price;
-        token.balance += uint128(sellAmount);
+        unchecked {
+            require(token.balance + sellAmount <= type(uint128).max, "BobVault: amount too large");
+            token.balance += uint128(sellAmount);
+        }
 
         bobToken.transfer(msg.sender, buyAmount);
 
@@ -438,7 +441,10 @@ contract BobVault is EIP1967Admin, Ownable, YieldConnector {
 
         uint256 fee = _amount * uint256(inToken.inFee) / 1 ether;
         uint256 sellAmount = _amount - fee;
-        inToken.balance += uint128(sellAmount);
+        unchecked {
+            require(inToken.balance + sellAmount <= type(uint128).max, "BobVault: amount too large");
+            inToken.balance += uint128(sellAmount);
+        }
         uint256 bobAmount = sellAmount * 1 ether / inToken.price;
 
         // sell virtual bob
@@ -548,7 +554,10 @@ contract BobVault is EIP1967Admin, Ownable, YieldConnector {
 
         IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
 
-        token.balance += uint128(_amount);
+        unchecked {
+            require(token.balance + _amount <= type(uint128).max, "BobVault: amount too large");
+            token.balance += uint128(_amount);
+        }
 
         emit Give(_token, _amount);
     }

--- a/src/zkbob/utils/ZkBobAccounting.sol
+++ b/src/zkbob/utils/ZkBobAccounting.sol
@@ -218,6 +218,7 @@ contract ZkBobAccounting {
             }
         } else {
             uint256 withdrawAmount = uint256(-_txAmount);
+            require(withdrawAmount <= type(uint32).max * PRECISION, "ZkBobAccounting: withdrawal amount too large");
             s1.tvl -= uint72(withdrawAmount);
 
             if (isDayTransition) {
@@ -249,6 +250,9 @@ contract ZkBobAccounting {
     {
         require(_tier < 255, "ZkBobAccounting: invalid limit tier");
         require(_depositCap > 0, "ZkBobAccounting: zero deposit cap");
+        require(_tvlCap <= type(uint56).max * PRECISION, "ZkBobAccounting: tvl cap too large");
+        require(_dailyDepositCap <= type(uint32).max * PRECISION, "ZkBobAccounting: daily deposit cap too large");
+        require(_dailyWithdrawalCap <= type(uint32).max * PRECISION, "ZkBobAccounting: daily withdrawal cap too large");
         require(_dailyUserDepositCap >= _depositCap, "ZkBobAccounting: daily user deposit cap too low");
         require(_dailyDepositCap >= _dailyUserDepositCap, "ZkBobAccounting: daily deposit cap too low");
         require(_tvlCap >= _dailyDepositCap, "ZkBobAccounting: tvl cap too low");

--- a/test/zkbob/utils/ZkBobAccounting.t.sol
+++ b/test/zkbob/utils/ZkBobAccounting.t.sol
@@ -497,4 +497,13 @@ contract ZkBobAccountingTest is Test {
         assertEq(limits3.depositCap, 0 gwei);
         assertEq(limits3.tier, 255);
     }
+
+    function testPoolLimitsTooLarge() public {
+        vm.expectRevert("ZkBobAccounting: tvl cap too large");
+        pool.setLimits(0, 1e18 ether, 500 ether, 400 ether, 300 ether, 150 ether);
+        vm.expectRevert("ZkBobAccounting: daily deposit cap too large");
+        pool.setLimits(0, 1e16 ether, 1e10 ether, 400 ether, 300 ether, 150 ether);
+        vm.expectRevert("ZkBobAccounting: daily withdrawal cap too large");
+        pool.setLimits(0, 1e16 ether, 500 ether, 1e10 ether, 300 ether, 150 ether);
+    }
 }


### PR DESCRIPTION
There are some places in the code with missing overflow checks on uint downcasting to smaller bit sizes. Although it seems impossible to observe such values in practice, it makes sense to add missing overflow sanity checks.