### PR TITLE
Add warning comment for possible sellForETH slippage

### DIFF
--- a/src/utils/UniswapV3Seller.sol
+++ b/src/utils/UniswapV3Seller.sol
@@ -41,6 +41,8 @@ contract UniswapV3Seller is ITokenSeller {
     /**
      * @dev Sells tokens for ETH.
      * Prior to calling this function, contract balance of token0 should be greater than or equal to the sold amount.
+     * Note: this implementation does not include any slippage/sandwich protection,
+     * users are strongly discouraged from using this contract for exchanging significant amounts.
      * @param _receiver native ETH receiver.
      * @param _amount amount of tokens to sell.
      * @return (received eth amount, refunded token amount).


### PR DESCRIPTION
When the withdrawal with native_amount is submitted to the ZkBobPool, the sale of tokens for ETH happens using the UniswapV3Seller contract. However, the amountOutMinimum parameter of this swap is 0. A potential attacker can place orders that would manipulate the price, forcing the sellForETH trade to be executed with a bad price. Thus, due to the lack of spread control, any use of UniswapV3Seller can result in a bad trade, allowing price manipulators to pocket the profit from this trade.

_Comments to changes:_
This feature is only intended to swap small amounts of tokens, purely for funding wallets with gas tokens. UI will strongly dissuade users for doing swaps that are larger than e.g. 100$ in value.
Added a warning comment to the sellForETH function.