### PR TITLE
Add per-collateral limits to BobVault

### DIFF
--- a/script/scripts/BobVault.s.sol
+++ b/script/scripts/BobVault.s.sol
@@ -38,7 +38,9 @@ contract DeployBobVault is Script {
                     yield: yield,
                     price: vaultCollateralPrice,
                     inFee: vaultCollateralInFee,
-                    outFee: vaultCollateralOutFee
+                    outFee: vaultCollateralOutFee,
+                    maxBalance: type(uint128).max,
+                    maxInvested: type(uint128).max
                 })
             );
 

--- a/test/BobVault.t.sol
+++ b/test/BobVault.t.sol
@@ -53,7 +53,12 @@ contract BobVaultTest is AbstractBobVaultTest {
         vm.startPrank(user1);
 
         vm.expectRevert("Ownable: caller is not the owner");
-        vault.addCollateral(address(tokenA), BobVault.Collateral(0, 0, 0, address(0), 1000000, 0.01 ether, 0.01 ether));
+        vault.addCollateral(
+            address(tokenA),
+            BobVault.Collateral(
+                0, 0, 0, address(0), 1000000, 0.01 ether, 0.01 ether, type(uint128).max, type(uint128).max
+            )
+        );
         vm.expectRevert("Ownable: caller is not the owner");
         vault.setInvestAdmin(user2);
         vm.expectRevert("Ownable: caller is not the owner");
@@ -61,11 +66,13 @@ contract BobVaultTest is AbstractBobVaultTest {
         vm.expectRevert("Ownable: caller is not the owner");
         vault.setCollateralFees(address(tokenA), 0.01 ether, 0.01 ether);
         vm.expectRevert("Ownable: caller is not the owner");
-        vault.enableCollateralYield(address(tokenA), address(0), 1_000_000 * 1e6, 1e6);
+        vault.enableCollateralYield(address(tokenA), address(0), 1_000_000 * 1e6, 1e6, type(uint128).max);
         vm.expectRevert("Ownable: caller is not the owner");
         vault.disableCollateralYield(address(tokenA));
         vm.expectRevert("Ownable: caller is not the owner");
-        vault.updateCollateralYield(address(tokenA), 1_000_000 * 1e6, 1e6);
+        vault.updateCollateralYield(address(tokenA), 1_000_000 * 1e6, 1e6, type(uint128).max);
+        vm.expectRevert("Ownable: caller is not the owner");
+        vault.setMaxBalance(address(tokenA), type(uint128).max);
         vm.expectRevert("Ownable: caller is not the owner");
         vault.reclaim(user1, 1e6);
         vm.expectRevert("Ownable: caller is not the owner");
@@ -145,9 +152,24 @@ abstract contract AbstractBobVault3poolTest is AbstractBobVaultTest, AbstractFor
         assertEq(vault.isCollateral(address(usdc)), false);
         assertEq(vault.isCollateral(address(usdt)), false);
         assertEq(vault.isCollateral(address(dai)), false);
-        vault.addCollateral(address(usdc), BobVault.Collateral(0, 0, 0, address(0), 1e6, 0.001 ether, 0.002 ether));
-        vault.addCollateral(address(usdt), BobVault.Collateral(0, 0, 0, address(0), 1e6, 0.003 ether, 0.004 ether));
-        vault.addCollateral(address(dai), BobVault.Collateral(0, 0, 0, address(0), 1 ether, 0.005 ether, 0.006 ether));
+        vault.addCollateral(
+            address(usdc),
+            BobVault.Collateral(
+                0, 0, 0, address(0), 1e6, 0.001 ether, 0.002 ether, type(uint128).max, type(uint128).max
+            )
+        );
+        vault.addCollateral(
+            address(usdt),
+            BobVault.Collateral(
+                0, 0, 0, address(0), 1e6, 0.003 ether, 0.004 ether, type(uint128).max, type(uint128).max
+            )
+        );
+        vault.addCollateral(
+            address(dai),
+            BobVault.Collateral(
+                0, 0, 0, address(0), 1 ether, 0.005 ether, 0.006 ether, type(uint128).max, type(uint128).max
+            )
+        );
         assertEq(vault.isCollateral(address(usdc)), true);
         assertEq(vault.isCollateral(address(usdt)), true);
         assertEq(vault.isCollateral(address(dai)), true);
@@ -351,6 +373,33 @@ abstract contract AbstractBobVault3poolTest is AbstractBobVaultTest, AbstractFor
         assertGt(bob.balanceOf(user1), 700 ether);
         vm.stopPrank();
     }
+
+    function testMaxBalance() public {
+        _setup3pool(100 ether);
+
+        vm.expectRevert("BobVault: unsupported collateral");
+        vault.setMaxBalance(address(this), 50 * 1e6);
+
+        vault.setMaxBalance(address(usdc), 50 * 1e6);
+
+        vault.buy(address(usdc), 30 * 1e6);
+        vault.buy(address(usdt), 30 * 1e6);
+
+        vm.expectRevert("BobVault: exceeds max balance");
+        vault.buy(address(usdc), 30 * 1e6);
+        vm.expectRevert("BobVault: exceeds max balance");
+        vault.swap(address(usdc), address(usdt), 30 * 1e6);
+
+        vault.buy(address(usdc), 20 * 1e6);
+        vm.expectRevert("BobVault: exceeds max balance");
+        vault.swap(address(usdc), address(usdt), 20 * 1e6);
+
+        vault.sell(address(usdc), 20 ether);
+        vault.swap(address(usdc), address(usdt), 20 * 1e6);
+
+        BobVault.Stat memory stat = vault.stat(address(usdc));
+        assertEq(stat.required, 50 * 1e6 - 70 * 1e6 * 0.001);
+    }
 }
 
 abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractForkTest {
@@ -391,7 +440,18 @@ abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractFork
 
         AAVEYieldImplementation aImpl = new AAVEYieldImplementation(lendingPool);
         vault.addCollateral(
-            address(usdc), BobVault.Collateral(0, 1_000_000 * 1e6, 1e6, address(aImpl), 1e6, 0.001 ether, 0.002 ether)
+            address(usdc),
+            BobVault.Collateral(
+                0,
+                1_000_000 * 1e6,
+                1e6,
+                address(aImpl),
+                1e6,
+                0.001 ether,
+                0.002 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
 
         bob.mint(address(vault), 100_000_000 ether);
@@ -413,14 +473,46 @@ abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractFork
 
         AAVEYieldImplementation aImpl = new AAVEYieldImplementation(lendingPool);
         vault.addCollateral(
-            address(usdc), BobVault.Collateral(0, 1_000_000 * 1e6, 1e6, address(aImpl), 1e6, 0.001 ether, 0.002 ether)
+            address(usdc),
+            BobVault.Collateral(
+                0,
+                1_000_000 * 1e6,
+                1e6,
+                address(aImpl),
+                1e6,
+                0.001 ether,
+                0.002 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         vault.addCollateral(
-            address(usdt), BobVault.Collateral(0, 1_000_000 * 1e6, 1e6, address(aImpl), 1e6, 0.003 ether, 0.004 ether)
+            address(usdt),
+            BobVault.Collateral(
+                0,
+                1_000_000 * 1e6,
+                1e6,
+                address(aImpl),
+                1e6,
+                0.003 ether,
+                0.004 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         vault.addCollateral(
             address(dai),
-            BobVault.Collateral(0, 1_000_000 ether, 1 ether, address(aImpl), 1 ether, 0.005 ether, 0.006 ether)
+            BobVault.Collateral(
+                0,
+                1_000_000 ether,
+                1 ether,
+                address(aImpl),
+                1 ether,
+                0.005 ether,
+                0.006 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
 
         bob.mint(address(vault), 100_000_000 ether);
@@ -485,7 +577,7 @@ abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractFork
         uint256 investedAmount1 = _getAToken(address(usdc)).balanceOf(address(vault));
         assertGt(investedAmount1, 0);
 
-        vault.updateCollateralYield(address(usdc), 100_000 * 1e6, 10 * 1e6);
+        vault.updateCollateralYield(address(usdc), 100_000 * 1e6, 10 * 1e6, type(uint128).max);
 
         uint256 investedAmount2 = _getAToken(address(usdc)).balanceOf(address(vault));
         assertGt(investedAmount2, investedAmount1);
@@ -536,7 +628,7 @@ abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractFork
         assertEq(_getAToken(address(usdc)).balanceOf(address(vault)), 0);
 
         address aImpl = address(new AAVEYieldImplementation(lendingPool));
-        vault.enableCollateralYield(address(usdc), aImpl, 100_000 * 1e6, 10 * 1e6);
+        vault.enableCollateralYield(address(usdc), aImpl, 100_000 * 1e6, 10 * 1e6, type(uint128).max);
 
         stat = vault.stat(address(usdc));
         assertGt(stat.total, 10_000_002 * 1e6);
@@ -576,6 +668,22 @@ abstract contract AbstractBobVaultAAVETest is AbstractBobVaultTest, AbstractFork
         assertLt(usdc.balanceOf(address(vault)), 900_000 * 1e6);
 
         assertEq(_getAToken(address(usdc)).balanceOf(address(vault)), 0);
+    }
+
+    function testAAVEMaxInvested() public {
+        _setupAAVEYieldForUSDC();
+
+        vault.updateCollateralYield(address(usdc), 1_000_000 * 1e6, 1e6, 2_000_000 * 1e6);
+        assertGt(_getAToken(address(usdc)).balanceOf(address(vault)), 9_000_000 * 1e6);
+
+        vm.prank(user1);
+        vault.sell(address(usdc), 9_000_000 ether);
+        vm.prank(user1);
+        vault.buy(address(usdc), 4_000_000 * 1e6);
+
+        vault.invest(address(usdc));
+
+        assertApproxEqAbs(_getAToken(address(usdc)).balanceOf(address(vault)), 2_000_000 * 1e6, 1000);
     }
 
     function _getAToken(address _token) internal returns (IERC20) {


### PR DESCRIPTION
After some usage of BobVault in production, necessity in few more limits appeared

## Changelog
* Add `maxBalance` per-collateral configuration, which describes max amount of backing collateral (without accounting for fees). `buy` and `swap` operations will revert if such limit is exceeded. Previously, an implicit constant limit of `type(uint128).max` was used for all collaterals.
* Add `maxInvested` per-collateral configuration, which describes max amount of tokens that could be invested into the yield bearing protocol. This configuration only impacts calls to `invest` and restricts invested amount if necessary.