### PR TITLE
Explicit storage slot to keep KycProvidersManager

### DIFF
--- a/src/zkbob/utils/KycProvidersManagerStorage.sol
+++ b/src/zkbob/utils/KycProvidersManagerStorage.sol
@@ -12,7 +12,8 @@ contract KycProvidersManagerStorage is Ownable {
     // a free slot explicitly. Similar approach is used in EIP1967.
     //
     // bytes32(uint256(keccak256('zkBob.ZkBobAccounting.kycProvidersManager')) - 1)
-    uint256 internal constant KYC_PROVIDER_MANAGER_STORAGE = 0x06c991646992b7f0f3fd0c832eac3f519e26682bcb82fbbcfd1ff8013d876f64;
+    uint256 internal constant KYC_PROVIDER_MANAGER_STORAGE =
+        0x06c991646992b7f0f3fd0c832eac3f519e26682bcb82fbbcfd1ff8013d876f64;
 
     event UpdateKYCProvidersManager(address manager);
 

--- a/src/zkbob/utils/KycProvidersManagerStorage.sol
+++ b/src/zkbob/utils/KycProvidersManagerStorage.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.8.15;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "../../interfaces/IKycProvidersManager.sol";
+import "../../utils/Ownable.sol";
+
+contract KycProvidersManagerStorage is Ownable {
+    // In order to avoid shifting storage slots by defining a new variable in
+    // the contract, KYC Providers Manager will be accessed through specifying
+    // a free slot explicitly. Similar approach is used in EIP1967.
+    //
+    // bytes32(uint256(keccak256('zkBob.ZkBobAccounting.kycProvidersManager')) - 1)
+    uint256 internal constant KYC_PROVIDER_MANAGER_STORAGE = 0x06c991646992b7f0f3fd0c832eac3f519e26682bcb82fbbcfd1ff8013d876f64;
+
+    event UpdateKYCProvidersManager(address manager);
+
+    /**
+     * @dev Tells the KYC Providers Manager contract address.
+     * @return res the manager address.
+     */
+    function kycProvidersManager() public view returns (IKycProvidersManager res) {
+        assembly {
+            res := sload(KYC_PROVIDER_MANAGER_STORAGE)
+        }
+    }
+
+    /**
+     * @dev Updates kyc providers manager contract.
+     * Callable only by the contract owner / proxy admin.
+     * @param _kycProvidersManager new operator manager implementation.
+     */
+    function setKycProvidersManager(IKycProvidersManager _kycProvidersManager) external onlyOwner {
+        require(Address.isContract(address(_kycProvidersManager)), "KycProvidersManagerStorage: not a contract");
+        assembly {
+            sstore(KYC_PROVIDER_MANAGER_STORAGE, _kycProvidersManager)
+        }
+        emit UpdateKYCProvidersManager(address(_kycProvidersManager));
+    }
+}

--- a/test/zkbob/utils/ZkBobAccounting.t.sol
+++ b/test/zkbob/utils/ZkBobAccounting.t.sol
@@ -538,7 +538,7 @@ contract ZkBobAccountingTest is Test {
         address manager = address(_setKYCPorviderManager());
         assertEq(address(pool.kycProvidersManager()), manager);
 
-        vm.expectRevert("ZkBobPool: manager is zero address");
+        vm.expectRevert("KycProvidersManagerStorage: not a contract");
         pool.setKycProvidersManager(SimpleKYCProviderManager(address(0)));
     }
 


### PR DESCRIPTION
This approach was chosen to avoid storage slots re-arrangement that could happen after upgrade to the new implementation of zkBOB pool.

It suggests to dedicate the slot `0x06c991646992b7f0f3fd0c832eac3f519e26682bcb82fbbcfd1ff8013d876f64` to keep the KYC Providers Manager contract address.