### PR TITLE
Add forced exit

### DIFF
--- a/script/scripts/DeployZkBobPoolModules.s.sol
+++ b/script/scripts/DeployZkBobPoolModules.s.sol
@@ -8,7 +8,6 @@ import "./Env.s.sol";
 import "../../src/zkbob/ZkBobPool.sol";
 import "../../src/zkbob/utils/ZkBobAccounting.sol";
 import "../../src/proxy/EIP1967Proxy.sol";
-import "../../src/zkbob/ZkBobPoolBOB.sol";
 import "../../src/zkbob/ZkBobPoolUSDC.sol";
 
 contract DummyDelegateCall {

--- a/src/interfaces/IZkBobAccounting.sol
+++ b/src/interfaces/IZkBobAccounting.sol
@@ -8,7 +8,8 @@ interface IZkBobAccounting {
     enum TxType {
         Common,
         DirectDeposit,
-        AppendDirectDeposits
+        AppendDirectDeposits,
+        ForcedExit
     }
 
     struct Limits {

--- a/src/interfaces/IZkBobPool.sol
+++ b/src/interfaces/IZkBobPool.sol
@@ -5,14 +5,6 @@ pragma solidity ^0.8.0;
 import "./IZkBobAccounting.sol";
 
 interface IZkBobPool {
-    struct ForcedExitParams {
-        address to;
-        uint64 amount;
-        address operator;
-        uint40 exitStart;
-        uint40 exitEnd;
-    }
-
     function pool_id() external view returns (uint256);
 
     function denominator() external view returns (uint256);

--- a/src/interfaces/IZkBobPool.sol
+++ b/src/interfaces/IZkBobPool.sol
@@ -5,6 +5,14 @@ pragma solidity ^0.8.0;
 import "./IZkBobAccounting.sol";
 
 interface IZkBobPool {
+    struct ForcedExitParams {
+        address to;
+        uint64 amount;
+        address operator;
+        uint40 exitStart;
+        uint40 exitEnd;
+    }
+
     function pool_id() external view returns (uint256);
 
     function denominator() external view returns (uint256);

--- a/src/zkbob/utils/ZkBobAccounting.sol
+++ b/src/zkbob/utils/ZkBobAccounting.sol
@@ -297,7 +297,7 @@ contract ZkBobAccounting is IZkBobAccounting, Ownable {
         }
         if (_txType == IZkBobAccounting.TxType.ForcedExit) {
             require(_txAmount > 0, "ZkBobAccounting: negative amount");
-            s1.tvl -= uint72(uint256(_txAmount));
+            slot1.tvl -= uint72(uint256(_txAmount));
             return;
         }
 

--- a/src/zkbob/utils/ZkBobAccounting.sol
+++ b/src/zkbob/utils/ZkBobAccounting.sol
@@ -295,6 +295,11 @@ contract ZkBobAccounting is IZkBobAccounting, Ownable {
             _recordDirectDeposit(_user, uint256(_txAmount));
             return;
         }
+        if (_txType == IZkBobAccounting.TxType.ForcedExit) {
+            require(_txAmount > 0, "ZkBobAccounting: negative amount");
+            s1.tvl -= uint72(uint256(_txAmount));
+            return;
+        }
 
         Slot0 memory s0 = slot0;
         Slot1 memory s1 = slot1;

--- a/test/interfaces/IZkBobPoolAdmin.sol
+++ b/test/interfaces/IZkBobPoolAdmin.sol
@@ -38,7 +38,15 @@ interface IZkBobPoolAdmin {
     )
         external;
 
-    function executeForcedExit(uint256 _nullifier) external;
+    function executeForcedExit(
+        uint256 _nullifier,
+        address _operator,
+        address _to,
+        uint256 _amount,
+        uint256 _exitStart,
+        uint256 _exitEnd
+    )
+        external;
 
     function appendDirectDeposits(
         uint256 _root_after,

--- a/test/interfaces/IZkBobPoolAdmin.sol
+++ b/test/interfaces/IZkBobPoolAdmin.sol
@@ -27,6 +27,16 @@ interface IZkBobPoolAdmin {
 
     function transact() external;
 
+    function forceExit(
+        address _to,
+        uint256 _amount,
+        uint256 _index,
+        uint256 _nullifier,
+        uint256 _out_commit,
+        uint256[8] memory _transfer_proof
+    )
+        external;
+
     function appendDirectDeposits(
         uint256 _root_after,
         uint256[] calldata _indices,

--- a/test/interfaces/IZkBobPoolAdmin.sol
+++ b/test/interfaces/IZkBobPoolAdmin.sol
@@ -27,7 +27,8 @@ interface IZkBobPoolAdmin {
 
     function transact() external;
 
-    function forceExit(
+    function commitForcedExit(
+        address _operator,
         address _to,
         uint256 _amount,
         uint256 _index,
@@ -36,6 +37,8 @@ interface IZkBobPoolAdmin {
         uint256[8] memory _transfer_proof
     )
         external;
+
+    function executeForcedExit(uint256 _nullifier) external;
 
     function appendDirectDeposits(
         uint256 _root_after,

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -304,6 +304,19 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         assertEq(IERC20(token).balanceOf(user3), 0.02 ether / D);
     }
 
+    function testForcedExit() public {
+        bytes memory data = _encodePermitDeposit(int256(0.5 ether / D), 0.01 ether / D);
+        _transact(data);
+
+        uint256 nullifier = _randFR();
+        pool.forceExit(user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+        assertEq(IERC20(token).balanceOf(user2), 0.4 ether / D);
+        assertEq(pool.nullifiers(nullifier), 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead0000000000000080);
+
+        vm.expectRevert("ZkBobPool: doublespend detected");
+        pool.forceExit(user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+    }
+
     function testRejectNegativeDeposits() public {
         bytes memory data1 = _encodePermitDeposit(int256(0.99 ether / D), 0.01 ether / D);
         _transact(data1);

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -304,7 +304,7 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         assertEq(IERC20(token).balanceOf(user3), 0.02 ether / D);
     }
 
-    function testForcedExit() public {
+    function testForceExit() public {
         bytes memory data = _encodePermitDeposit(int256(0.5 ether / D), 0.01 ether / D);
         _transact(data);
 


### PR DESCRIPTION
Add forced exit functionality that allows any user for withdraw funds from the pool in case of an emergency(e.g. prolonged sequencer outage).
Forced exits can be submitted directly to the smart contract, bypassing the relayer, by generating a valid withdrawal proof. Forced exited accounts cannot be further used or recovered, accumulated energy of forced exited account is being forfeited during the exit.