### PR TITLE
Fix forced exit re-use

### DIFF
--- a/test/interfaces/IZkBobPoolAdmin.sol
+++ b/test/interfaces/IZkBobPoolAdmin.sol
@@ -27,6 +27,8 @@ interface IZkBobPoolAdmin {
 
     function transact() external;
 
+    function committedForcedExits(uint256 _nullifier) external view returns (bytes32);
+
     function commitForcedExit(
         address _operator,
         address _to,
@@ -44,7 +46,8 @@ interface IZkBobPoolAdmin {
         address _to,
         uint256 _amount,
         uint256 _exitStart,
-        uint256 _exitEnd
+        uint256 _exitEnd,
+        bool _cancel
     )
         external;
 

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -317,27 +317,27 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         assertEq(pool.nullifiers(nullifier), 0);
 
         vm.expectRevert("ZkBobPool: invalid forced exit");
-        pool.executeForcedExit(nullifier ^ 1, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier ^ 1, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         vm.expectRevert("ZkBobPool: invalid forced exit");
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, block.timestamp, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, block.timestamp, exitEnd, false);
 
         vm.expectRevert("ZkBobPool: invalid caller");
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         vm.startPrank(user2);
         vm.expectRevert("ZkBobPool: exit not allowed");
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         skip(25 hours);
         vm.expectRevert("ZkBobPool: exit not allowed");
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         rewind(23 hours);
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         vm.expectRevert("ZkBobPool: doublespend detected");
-        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd);
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, false);
 
         assertEq(IERC20(token).balanceOf(user2), 0.4 ether / D);
         assertEq(pool.nullifiers(nullifier), 0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead0000000000000080);
@@ -346,6 +346,39 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         pool.commitForcedExit(user2, user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
 
         vm.stopPrank();
+    }
+
+    function testCancelForcedExit() public {
+        bytes memory data = _encodePermitDeposit(int256(0.5 ether / D), 0.01 ether / D);
+        _transact(data);
+
+        uint256 nullifier = _randFR();
+        pool.commitForcedExit(user2, user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+        uint256 exitStart = block.timestamp + 1 hours;
+        uint256 exitEnd = block.timestamp + 24 hours;
+        bytes32 hash = pool.committedForcedExits(nullifier);
+        assertNotEq(hash, bytes32(0));
+
+        vm.expectRevert("ZkBobPool: exit not expired");
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, true);
+        vm.expectRevert("ZkBobPool: already exists");
+        pool.commitForcedExit(user2, user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+
+        skip(12 hours);
+
+        vm.expectRevert("ZkBobPool: exit not expired");
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, true);
+        vm.expectRevert("ZkBobPool: already exists");
+        pool.commitForcedExit(user2, user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+
+        skip(24 hours);
+
+        pool.executeForcedExit(nullifier, user2, user2, 0.4 ether / D / denominator, exitStart, exitEnd, true);
+        assertEq(pool.committedForcedExits(nullifier), bytes32(0));
+
+        pool.commitForcedExit(user2, user2, 0.4 ether / D / denominator, 128, nullifier, _randFR(), _randProof());
+        assertNotEq(pool.committedForcedExits(nullifier), bytes32(0));
+        assertNotEq(pool.committedForcedExits(nullifier), hash);
     }
 
     function testRejectNegativeDeposits() public {


### PR DESCRIPTION
Previous implementation contained a bug, allowing anyone to infinitely resubmit the same forced exit proof again and again, effectively preventing exiting party from ever finalizing the withdrawal.

One way to fix that - disallow forced exit submission for nullifiers for which forced exists already exist. However, in order for exiting party to still be able to re-submit their forced exit after 24 hours, extra cancellation method is needed.