### PR TITLE
Support new message prefix

### DIFF
--- a/script/scripts/DeployZkBobPoolModules.s.sol
+++ b/script/scripts/DeployZkBobPoolModules.s.sol
@@ -64,8 +64,12 @@ contract DeployZkBobPoolModules is Script, Test {
         vm.startBroadcast();
 
         ZkBobPoolUSDC impl = new ZkBobPoolUSDC(
-            pool.pool_id(), pool.token(), pool.transfer_verifier(), pool.tree_verifier(),
-            pool.batch_deposit_verifier(), address(pool.direct_deposit_queue())
+            pool.pool_id(),
+            pool.token(),
+            pool.transfer_verifier(),
+            pool.tree_verifier(),
+            pool.batch_deposit_verifier(),
+            address(pool.direct_deposit_queue())
         );
         Migrator mig = new Migrator();
         ZkBobAccounting acc = new ZkBobAccounting(address(pool), 1_000_000_000);

--- a/script/scripts/Local.s.sol
+++ b/script/scripts/Local.s.sol
@@ -45,12 +45,7 @@ contract DeployLocal is Script {
         EIP1967Proxy queueProxy = new EIP1967Proxy(tx.origin, mockImpl, "");
 
         ZkBobPoolBOB poolImpl = new ZkBobPoolBOB(
-            zkBobPoolId,
-            address(bob),
-            transferVerifier,
-            treeVerifier,
-            batchDepositVerifier,
-            address(queueProxy)
+            zkBobPoolId, address(bob), transferVerifier, treeVerifier, batchDepositVerifier, address(queueProxy)
         );
         {
             bytes memory initData = abi.encodeWithSelector(ZkBobPool.initialize.selector, zkBobInitialRoot);

--- a/script/scripts/ZkBobPool.s.sol
+++ b/script/scripts/ZkBobPool.s.sol
@@ -53,27 +53,31 @@ contract DeployZkBobPool is Script {
 
         if (zkBobPoolType == PoolType.ETH) {
             vars.poolImpl = new ZkBobPoolETH(
-                zkBobPoolId, zkBobToken,
-                transferVerifier, treeVerifier, batchDepositVerifier,
-                address(vars.queueProxy), permit2
+                zkBobPoolId,
+                zkBobToken,
+                transferVerifier,
+                treeVerifier,
+                batchDepositVerifier,
+                address(vars.queueProxy),
+                permit2
             );
         } else if (zkBobPoolType == PoolType.BOB) {
             vars.poolImpl = new ZkBobPoolBOB(
-                zkBobPoolId, zkBobToken,
-                transferVerifier, treeVerifier, batchDepositVerifier,
-                address(vars.queueProxy)
+                zkBobPoolId, zkBobToken, transferVerifier, treeVerifier, batchDepositVerifier, address(vars.queueProxy)
             );
         } else if (zkBobPoolType == PoolType.USDC) {
             vars.poolImpl = new ZkBobPoolUSDC(
-                zkBobPoolId, zkBobToken,
-                transferVerifier, treeVerifier, batchDepositVerifier,
-                address(vars.queueProxy)
+                zkBobPoolId, zkBobToken, transferVerifier, treeVerifier, batchDepositVerifier, address(vars.queueProxy)
             );
         } else if (zkBobPoolType == PoolType.ERC20) {
             vars.poolImpl = new ZkBobPoolERC20(
-                zkBobPoolId, zkBobToken,
-                transferVerifier, treeVerifier, batchDepositVerifier,
-                address(vars.queueProxy), permit2,
+                zkBobPoolId,
+                zkBobToken,
+                transferVerifier,
+                treeVerifier,
+                batchDepositVerifier,
+                address(vars.queueProxy),
+                permit2,
                 vars.denominator
             );
         } else {

--- a/src/zkbob/ZkBobPool.sol
+++ b/src/zkbob/ZkBobPool.sol
@@ -34,6 +34,7 @@ abstract contract ZkBobPool is IZkBobPool, EIP1967Admin, Ownable, Parameters, Ex
 
     uint256 internal constant MAX_POOL_ID = 0xffffff;
     bytes4 internal constant MESSAGE_PREFIX_COMMON_V1 = 0x00000000;
+    bytes4 internal constant MESSAGE_PREFIX_COMMON_V2 = 0x00000100;
     uint256 internal constant FORCED_EXIT_MIN_DELAY = 1 hours;
     uint256 internal constant FORCED_EXIT_MAX_DELAY = 24 hours;
 
@@ -236,7 +237,7 @@ abstract contract ZkBobPool is IZkBobPool, EIP1967Admin, Ownable, Parameters, Ex
             roots[poolIndex] = _tree_root_after();
             bytes memory message = _memo_message();
             // restrict memo message prefix (items count in little endian) to be < 2**16
-            require(bytes4(message) & 0x0000ffff == MESSAGE_PREFIX_COMMON_V1, "ZkBobPool: bad message prefix");
+            require(_isValidPrefix(bytes4(message) & 0x0000ffff), "ZkBobPool: bad message prefix");
             bytes32 message_hash = keccak256(message);
             bytes32 _all_messages_hash = keccak256(abi.encodePacked(all_messages_hash, message_hash));
             all_messages_hash = _all_messages_hash;
@@ -511,5 +512,14 @@ abstract contract ZkBobPool is IZkBobPool, EIP1967Admin, Ownable, Parameters, Ex
      */
     function _isOwner() internal view override returns (bool) {
         return super._isOwner() || _admin() == _msgSender();
+    }
+
+    /**
+     * @dev Tells if given message prefix is valid.
+     * @param _prefix prefix to check.
+     * @return true, if prefix is valid.
+     */
+    function _isValidPrefix(bytes4 _prefix) internal pure returns (bool) {
+        return _prefix == MESSAGE_PREFIX_COMMON_V1 || _prefix == MESSAGE_PREFIX_COMMON_V2;
     }
 }

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -732,7 +732,7 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         data = _encodeTransferWithPrefix(0.01 ether / D, bytes2(0x0001));
         _transactReverted(data, "ZkBobPool: bad message prefix");
 
-         data = _encodeTransferWithPrefix(0.01 ether / D, bytes2(0x1234));
+        data = _encodeTransferWithPrefix(0.01 ether / D, bytes2(0x1234));
         _transactReverted(data, "ZkBobPool: bad message prefix");
     }
 
@@ -797,7 +797,8 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         for (uint256 i = 0; i < 17; i++) {
             data = abi.encodePacked(data, _randFR());
         }
-        return abi.encodePacked(data, uint16(1), uint16(44), uint64(_fee / denominator), bytes2(0x0100), prefix, _randFR());
+        return
+            abi.encodePacked(data, uint16(1), uint16(44), uint64(_fee / denominator), bytes2(0x0100), prefix, _randFR());
     }
 
     function _transact(bytes memory _data) internal {

--- a/test/zkbob/ZkBobPool.t.sol
+++ b/test/zkbob/ZkBobPool.t.sol
@@ -95,27 +95,42 @@ abstract contract AbstractZkBobPoolTest is AbstractForkTest {
         ZkBobPool impl;
         if (poolType == PoolType.ETH) {
             impl = new ZkBobPoolETH(
-                0, token,
-                new TransferVerifierMock(), new TreeUpdateVerifierMock(), new BatchDepositVerifierMock(),
-                address(queueProxy), permit2
+                0,
+                token,
+                new TransferVerifierMock(),
+                new TreeUpdateVerifierMock(),
+                new BatchDepositVerifierMock(),
+                address(queueProxy),
+                permit2
             );
         } else if (poolType == PoolType.BOB) {
             impl = new ZkBobPoolBOB(
-                0, token,
-                new TransferVerifierMock(), new TreeUpdateVerifierMock(), new BatchDepositVerifierMock(),
+                0,
+                token,
+                new TransferVerifierMock(),
+                new TreeUpdateVerifierMock(),
+                new BatchDepositVerifierMock(),
                 address(queueProxy)
             );
         } else if (poolType == PoolType.USDC) {
             impl = new ZkBobPoolUSDC(
-                0, token,
-                new TransferVerifierMock(), new TreeUpdateVerifierMock(), new BatchDepositVerifierMock(),
+                0,
+                token,
+                new TransferVerifierMock(),
+                new TreeUpdateVerifierMock(),
+                new BatchDepositVerifierMock(),
                 address(queueProxy)
             );
         } else if (poolType == PoolType.ERC20) {
             impl = new ZkBobPoolERC20(
-                0, token,
-                new TransferVerifierMock(), new TreeUpdateVerifierMock(), new BatchDepositVerifierMock(),
-                address(queueProxy), permit2, 1_000_000_000
+                0,
+                token,
+                new TransferVerifierMock(),
+                new TreeUpdateVerifierMock(),
+                new BatchDepositVerifierMock(),
+                address(queueProxy),
+                permit2,
+                1_000_000_000
             );
         }
 


### PR DESCRIPTION
This pull request enables the provision of a new message prefix for the `transact` function. This is essential to support the new memo encryption scheme described in https://github.com/zkBob/libzeropool-zkbob/issues/14.